### PR TITLE
make /etc/monit/default work in debian jessie and above

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,11 +44,20 @@ class monit::params {
       case $::operatingsystem {
         'Debian': {
           case $::lsbdistcodename {
-            'squeeze': { $service_has_status = false }
-            default:   { $service_has_status = true }
+            'squeeze': {
+              $service_has_status = false
+              $default_conf_tpl   = 'monit.default.conf.ubuntu.maverick.erb'
+            }
+            'wheezy': {
+              $service_has_status = true
+              $default_conf_tpl   = 'monit.default.conf.ubuntu.maverick.erb'
+            }
+            default:   {
+              $service_has_status = true
+              $default_conf_tpl = 'monit.default.conf.ubuntu.precise.erb'
+            }
           }
           $logrotate_source = 'logrotate.debian.erb'
-          $default_conf_tpl = 'monit.default.conf.ubuntu.maverick.erb'
         }
         'Ubuntu': {
           $logrotate_source   = 'logrotate.ubuntu.erb'


### PR DESCRIPTION
Hi,

monit will not start on Debian Jessie and later as the "start" variable has changed in /etc/default/monit

This patch uses the right (ubuntu-)template on squeeze, wheezy, jessie and above.

Greetz,
Andre
